### PR TITLE
Change youtube thumbnail URL

### DIFF
--- a/video.php
+++ b/video.php
@@ -199,7 +199,7 @@ class acf_field_video extends acf_field
 		
 		// get youtube thumbnail
 		if ( $video['type'] == 'youtube' )
-			$thumbnail_uri = 'http://img.youtube.com/vi/' . $video['id'] . '/hqdefault.jpg';
+			$thumbnail_uri = 'http://img.youtube.com/vi/' . $video['id'] . '/maxresdefault.jpg';
 		
 		// get vimeo thumbnail
 		if( $video['type'] == 'vimeo' )


### PR DESCRIPTION
Changing to `maxresdefault` instead of `hqdefault` removes black bars on 16:9 video thumbnails
